### PR TITLE
Clarification & Spelling Correction on Gumdrop ReadMe

### DIFF
--- a/js/packages/gumdrop/README.md
+++ b/js/packages/gumdrop/README.md
@@ -1,7 +1,7 @@
 # Gumdrop
 
-Deploy the website by modifying the `homepage` paramter in `path.json` and
-creating a `.env` file with the website pathname prefix e.g
+1) Deploy the website by modifying the `homepage` parameter in `package.json`
+2) Create an `.env` file with the website pathname prefix e.g
 
 ```
 echo 'REACT_APP_WEB_HOME="/gumdrop"' > .env


### PR DESCRIPTION
Fixes clarification / misspelling within the Gumdrop readme.

Before:
```
Deploy the website by modifying the `homepage` paramter in `path.json` and
creating a `.env` file with the website pathname prefix e.g
```
After:
```
1) Deploy the website by modifying the `homepage` parameter in `package.json`
2) Create an `.env` file with the website pathname prefix e.g
```